### PR TITLE
🐛 fix bug that prevented correct versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+
 [tool.cibuildwheel]
 build = "cp3*"
 archs = "auto64"


### PR DESCRIPTION
This PR fixes a bug that prevented automated versioning via `setuptools-scm` from working.