### PR TITLE
🐛 Fix broken sdist CI (caused by switch to Ubuntu 22.04)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,10 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Install Z3
         uses: cda-tum/setup-z3@v1
         with:


### PR DESCRIPTION
## Description

The recent GitHub runner update to Ubuntu 22.04 broke the sdist CI job. This PR fixes the job so that #210 should also be able to complete successfully.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
