### PR TITLE
📌 Pin `scikit-build-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "nanobind~=2.12.0",
-  "scikit-build-core>=0.12.2",
+  "scikit-build-core~=0.12",
   "setuptools-scm>=9.2.2",
   "mqt.core~=3.6.0",
 ]
@@ -329,7 +329,7 @@ mqt-qusat = { workspace = true }
 [dependency-groups]
 build = [
   "nanobind~=2.12.0",
-  "scikit-build-core>=0.12.2",
+  "scikit-build-core~=0.12",
   "setuptools-scm>=9.2.2",
   "mqt.core~=3.6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ provides-extras = ["qiskit"]
 build = [
     { name = "mqt-core", specifier = "~=3.6.0" },
     { name = "nanobind", specifier = "~=2.12.0" },
-    { name = "scikit-build-core", specifier = ">=0.12.2" },
+    { name = "scikit-build-core", specifier = "~=0.12" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 dev = [
@@ -1195,7 +1195,7 @@ dev = [
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "qiskit", extras = ["qasm3-import"], specifier = ">=1.0.0" },
-    { name = "scikit-build-core", specifier = ">=0.12.2" },
+    { name = "scikit-build-core", specifier = "~=0.12" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 docs = [


### PR DESCRIPTION
## Description

This PR pins `scikit-build-core` to `~=0.12` to prevent it from upgrading to version 1.0. The new version is incompatible with `nanobind.stubgen`. Once this issue is resolved, we can upgrade to 1.0 and benefit from the improved system for dynamic metadata. In particular, we should finally be able to drop our dependency on `setuptools-scm`.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.